### PR TITLE
Venue Datetime Parsing Fix

### DIFF
--- a/src/capture/main-channels/broadberry.ts
+++ b/src/capture/main-channels/broadberry.ts
@@ -1,4 +1,4 @@
-export const CAPTURE_KEY : string = 'broadberry';
+export const CAPTURE_KEY: string = 'broadberry';
 
 import { puppeteer, puppeteerUtils, apiClient, models, parsers, domUtils, captureHelpers, awsHelpers, screenshots } from '../../barrel';
 import { CFG } from '../../config';
@@ -8,7 +8,7 @@ let channelCfg = CFG[CAPTURE_KEY];
 
 export async function main() {
 
-  let bundledRuntimeDependencies : any = {
+  let bundledRuntimeDependencies: any = {
     channelCfg: channelCfg,
     curUri: channelCfg.PRIMARY_URI,
     CONTACT_ITEM_TYPES: models.CONTACT_ITEM_TYPES,
@@ -17,10 +17,10 @@ export async function main() {
     neighborhood: channelCfg.NEIGHBORHOOD
   };
 
-  let curDate : string = new Date().toISOString();
+  let curDate: string = new Date().toISOString();
 
   //init return values
-  let results : models.CaptureResults = {
+  let results: models.CaptureResults = {
     tenantName: channelCfg.TENANT_NAME,
     channelName: channelCfg.CHANNEL_NAME,
     channelBaseUri: channelCfg.PRIMARY_URI,
@@ -28,7 +28,7 @@ export async function main() {
     events: [] as models.CaptureEvent[],
   };
 
-  let log : models.CaptureLog = {
+  let log: models.CaptureLog = {
     tenantName: channelCfg.TENANT_NAME,
     channelName: channelCfg.CHANNEL_NAME,
     channelBaseUri: channelCfg.PRIMARY_URI,
@@ -40,11 +40,10 @@ export async function main() {
     totalCapturedEvents: 0
   };
 
-  try
-  {
+  try {
 
     //set up puppeteer and navigate to page
-    const [browser, page] = await puppeteerUtils.init({ debug: envCfg.debug, uri: channelCfg.PRIMARY_URI}, channelCfg.NAV_SETTINGS);
+    const [browser, page] = await puppeteerUtils.init({ debug: envCfg.debug, uri: channelCfg.PRIMARY_URI }, channelCfg.NAV_SETTINGS);
 
     //add helpers from parsers module into page
     await puppeteerUtils.injectHelpers(page, [parsers, domUtils], 'injectedHelpers');
@@ -53,32 +52,32 @@ export async function main() {
     //await puppeteerUtils.injectJquery(page, 'capJq');
 
     //capture from main page
-    [log, results] = await 
+    [log, results] = await
       page.$$eval<[models.CaptureLog, models.CaptureResults], models.CaptureResults, models.CaptureLog, any>(
-        channelCfg.DAY_EVENT_SELECTOR, 
-        captureHelpers.parseMainCamelPageBrowserFn,
+        channelCfg.DAY_EVENT_SELECTOR,
+        captureHelpers.parseMainCamelOrBroadberryPgBrwserFn,
         results,
         log,
         bundledRuntimeDependencies
-    ); //day eval
+      ); //day eval
 
     console.log(`identified ${results.events.length} events`);
 
     log = await screenshots.doScreenshot(log, page, channelCfg.PRIMARY_URI, envCfg.s3BucketName);
-    
+
     //Walk through each event in the results and navigate to its detail page
-    for(let i = 0; results.events.length > 0 && i < results.events.length; i++) {
+    for (let i = 0; results.events.length > 0 && i < results.events.length; i++) {
       let curEvent = results.events[i];
 
       //if venueName is BroadBerry, set location, etc.
       if (curEvent.venueName === channelCfg.VENUE_NAME) {
-        curEvent.location = { type: "Point", coordinates: channelCfg.COORDINATES};
+        curEvent.location = { type: "Point", coordinates: channelCfg.COORDINATES };
         curEvent.venueAddressLines = channelCfg.VENUE_ADDRESS;
-        curEvent.neighborhood = channelCfg.NEIGHBORHOOD;        
+        curEvent.neighborhood = channelCfg.NEIGHBORHOOD;
       } else {
         curEvent.location = curEvent.venueAddressLines = curEvent.neighborhood = null;
       }
-      
+
       //take only first event detail page (if exists)
       if (curEvent.eventUris && curEvent.eventUris.length > 0) {
         let eventDetailUri = curEvent.eventUris.filter(x => x.isCaptureSrc)[0];
@@ -99,14 +98,14 @@ export async function main() {
     log.totalCapturedEvents = results.events.length;
 
     if (envCfg.persistImagesToAws)
-      [ log, results ] = await awsHelpers.persistImagesToAws(log, results, envCfg.s3BucketName);
-        
+      [log, results] = await awsHelpers.persistImagesToAws(log, results, envCfg.s3BucketName);
+
   } catch (e) {
     log.errorLogs.push(`Top-Level Capture Page Exception Thrown: ${e.message} at ${channelCfg.PRIMARY_URI}`);
   } finally {
-    captureHelpers.outputLog(log);   
+    captureHelpers.outputLog(log);
   }
-    
+
   let testHttp = await apiClient.postCaptureResults(log, results);
 
   return 0;

--- a/src/capture/main-channels/the-national.ts
+++ b/src/capture/main-channels/the-national.ts
@@ -221,7 +221,12 @@ let parseNationalDetailPageBrowserFn = (detailCtx, curEvent: models.CaptureEvent
       let startTime = startTimeElem.innerText.replace("TIME\n","").trim();
       let [rawString, timeHours, timeMin] = injectedHelpers.parseTime(startTime);
       baseDate.setHours(timeHours, timeMin);
-      curEvent.startDt = baseDate.toISOString();
+ 
+      // pull isostring pull everything before letter T
+      let dateStr = baseDate.toISOString().split("T")[0];
+      // set the corrected date with the timezone we should be in GMT-0400 aka EST
+      let correctedDate = new Date(dateStr+" "+timeHours+":"+timeMin+":00"+" "+"GMT-0400");
+      curEvent.startDt = correctedDate.toISOString();
 
       //ticket info including link
       let ticketLinkElem = curCtx.querySelector('#event_detail_header a.btn-tickets');


### PR DESCRIPTION
For venues that parse start/end times from the scraper itself, these changes fix the errors seen in the timestamp pulled. 
- Creates a new timestamp in EST
- Converts and sends that UTC to be saved to the backend